### PR TITLE
Add Azure as option to 'Get Deis'

### DIFF
--- a/get-deis/index.html
+++ b/get-deis/index.html
@@ -31,6 +31,7 @@ meta:
                     <a href="http://docs.deis.io/en/latest/installing_deis/aws/" target="_blank">Amazon AWS</a>,
                     <a href="http://docs.deis.io/en/latest/installing_deis/digitalocean/" target="_blank">DigitalOcean</a>,
                     <a href="http://docs.deis.io/en/latest/installing_deis/gce/" target="_blank">Google Compute Engine</a>,
+                    <a href="http://docs.deis.io/en/latest/installing_deis/azure/" target="_blank">Microsoft Azure</a>,
                     <a href="http://docs.deis.io/en/latest/installing_deis/rackspace/" target="_blank">Rackspace</a>,
                     <a href="http://docs.deis.io/en/latest/installing_deis/vagrant/" target="_blank">Vagrant</a>
                     and


### PR DESCRIPTION
Mini-Change: Simply referenced the Azure installation documentation in
the ‘Get Deis’ Overview.