### PR TITLE
fix(config): use pygments highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: Deis
 url: http://deis.io
 tagline: Your Paas. Your Rules.
-highlighter: true
+highlighter: pygments
 gems:
   - jemoji
 markdown: redcarpet


### PR DESCRIPTION
In #113 we updated Jekyll's `_config.yml` but didn't get one change quite right, after which we started getting errors from GitHub:
> The page build completed successfully, but returned the following warning:

> Your site is using the 'true' highlighter, which is not currently supported on GitHub Pages. Highlighting on your site has been disabled. To re-enable, change your 'highlighter' value to 'pygments' in your '_config.yml'. Check out https://help.github.com/articles/page-build-failed-config-file-error#highlighting-errors for more information. 
