### PR TITLE
Remove ShopKeep's logo from "trusted by" list

### DIFF
--- a/_includes/user_logos.html
+++ b/_includes/user_logos.html
@@ -16,10 +16,6 @@
   </div>
   <div class="user-logo">
     <span class="helper"></span>
-    <a href="http://www.shopkeep.com/" target="_blank"><img src="/assets/img/logos/shopkeep.png" /></a>
-  </div>
-  <div class="user-logo">
-    <span class="helper"></span>
     <a href="https://instoredoes.com/" target="_blank"><img src="/assets/img/logos/instore.png" /></a>
   </div>
   <div class="user-logo">


### PR DESCRIPTION
ShopKeep has recently deprecated our Deis deployment.

To reflect this choice we would like to request our logo be removed from the "trusted by" list on Deis.io's front page. 