### PR TITLE
fix(config.yml): use rouge-highlighter instead of pygments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
-gem 'pygments.rb'
 
 group :import do
   gem 'jekyll-import'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,11 +106,7 @@ GEM
       mini_portile2 (~> 2.0.0.rc2)
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    posix-spawn (0.3.11)
     public_suffix (1.5.3)
-    pygments.rb (0.6.3)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.2.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -129,7 +125,6 @@ GEM
       ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
@@ -138,7 +133,6 @@ DEPENDENCIES
   github-pages
   hpricot
   jekyll-import
-  pygments.rb
   sequel
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: Deis
 url: http://deis.io
 tagline: Your Paas. Your Rules.
-highlighter: pygments
+highlighter: rouge
 gems:
   - jemoji
   - jekyll-paginate


### PR DESCRIPTION
I got another page warning after #142:

```
The page build completed successfully, but returned the following warning:

You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml'. For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.

GitHub Pages was recently upgraded to Jekyll 3.0. It may help to confirm you're using the correct dependencies:

  https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0

For information on troubleshooting Jekyll see:

  https://help.github.com/articles/using-jekyll-with-pages#troubleshooting

If you have any questions you can contact us by replying to this email.
```