### PR TITLE
Set the PROGRAM in the deis cli install to fix the failure messages

### DIFF
--- a/deis-cli/install-v2-alpha.sh
+++ b/deis-cli/install-v2-alpha.sh
@@ -43,6 +43,7 @@ function url_decode {
   printf '%b' "${url_encoded//%/\\x}"
 }
 
+PROGRAM="deis"
 PLATFORM="$(uname | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
 DEIS_ARTIFACT_REPO="${DEIS_ARTIFACT_REPO:-"deisci"}"
@@ -66,7 +67,7 @@ mv "${DEIS_CLI}" deis
 
 cat <<EOF
 
-deis is now available in your current directory.
+${PROGRAM} is now available in your current directory.
 
 To learn more about deis, execute:
 

--- a/deis-cli/install-v2.sh
+++ b/deis-cli/install-v2.sh
@@ -43,6 +43,7 @@ function url_decode {
   printf '%b' "${url_encoded//%/\\x}"
 }
 
+PROGRAM="deis"
 PLATFORM="$(uname | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
 DEIS_ARTIFACT_REPO="${DEIS_ARTIFACT_REPO:-"deisci"}"
@@ -66,7 +67,7 @@ mv "${DEIS_CLI}" deis
 
 cat <<EOF
 
-deis is now available in your current directory.
+${PROGRAM} is now available in your current directory.
 
 To learn more about deis, execute:
 


### PR DESCRIPTION
When trying to install
instead of a helpful error
I get the message

```
~ curl -sSL http://deis.io/deis-cli/install-v2.sh | bash
bash: line 34: PROGRAM: unbound variable
```

This should fix that.