### PR TITLE
chore(deis-cli/install-v2.sh): update workflow-cli bucket name

### DIFF
--- a/deis-cli/install-v2.sh
+++ b/deis-cli/install-v2.sh
@@ -49,8 +49,8 @@ function url_decode {
 PROGRAM="deis"
 PLATFORM="$(uname | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
-# https://storage.googleapis.com/workflow-cli/v2.0.0/deis-v2.0.0-darwin-386
-DEIS_BIN_URL_BASE="https://storage.googleapis.com/workflow-cli"
+# https://storage.googleapis.com/workflow-cli-release/v2.0.0/deis-v2.0.0-darwin-386
+DEIS_BIN_URL_BASE="https://storage.googleapis.com/workflow-cli-release"
 
 if [ "${ARCH}" == "x86_64" ]; then
   ARCH="amd64"


### PR DESCRIPTION
As the official releases now reside in the `workflow-cli-release` bucket.

(Former release versions v2.0.0-v2.4.0 have been copied over from the original `workflow-cli` bucket to the new one.)

Ref https://github.com/deis/jenkins-jobs/pull/211
Ref https://github.com/deis/workflow-cli/pull/190