### PR TITLE
ref(deis-cli/install-v2.sh): remove unused code

### DIFF
--- a/deis-cli/install-v2.sh
+++ b/deis-cli/install-v2.sh
@@ -28,24 +28,6 @@ EOF
   fi
 }
 
-function get_latest_version {
-  local url="${1}"
-  local version
-  version="$(curl -sI "${url}" | grep "Location:" | sed -n 's%.*deis/%%;s%/view.*%%p' )"
-
-  if [ -z "${version}" ]; then
-    echo "There doesn't seem to be a version of ${PROGRAM} avaiable at ${url}." 1>&2
-    return 1
-  fi
-
-  url_decode "${version}"
-}
-
-function url_decode {
-  local url_encoded="${1//+/ }"
-  printf '%b' "${url_encoded//%/\\x}"
-}
-
 PROGRAM="deis"
 PLATFORM="$(uname | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"


### PR DESCRIPTION
Removes `get_latest_version` and `url_decode` functions, neither of which I see use of in this script or elsewhere in this repo.