### PR TITLE
fix(deis-cli/install-v2.sh) Abort on curl error

### DIFF
--- a/deis-cli/install-v2.sh
+++ b/deis-cli/install-v2.sh
@@ -47,7 +47,7 @@ if [ "${VERSION}" != 'stable' ]; then
 fi
 
 echo "Downloading ${DEIS_CLI} From Google Cloud Storage..."
-curl -Ls -o deis "${DEIS_BIN_URL_BASE}/${DEIS_CLI_PATH}"
+curl -fsSL -o deis "${DEIS_BIN_URL_BASE}/${DEIS_CLI_PATH}"
 
 chmod +x deis
 


### PR DESCRIPTION
Without this fix the install script will run happily, even if the download url returns eg. a 404 error and writte the error html to the deis binary:

```sh
$ install-v2.sh v2.8.0
Downloading deis-v2.8.0-linux-amd64 From Google Cloud Storage...

deis is now available in your current directory.

To learn more about deis, execute:

    $ ./deis --help

$ cat deis
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>
```