### PR TITLE
fix(deis-cli): use POSIX compatible sh

### DIFF
--- a/deis-cli/install-v2.sh
+++ b/deis-cli/install-v2.sh
@@ -1,15 +1,15 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Invoking this script:
 #
 # To install the latest stable version:
-# curl http://deis.io/deis-cli/install-v2.sh | bash
+# curl https://deis.io/deis-cli/install-v2.sh | sh
 #
 # To install a specific released version ($VERSION):
-# curl http://deis.io/deis-cli/install-v2.sh | bash -x -s $VERSION
+# curl https://deis.io/deis-cli/install-v2.sh | sh -s $VERSION
 #
-# - download deis file
-# - making sure deis is executable
+# - download deis cli binary
+# - making sure deis cli binary is executable
 # - explain what was done
 #
 
@@ -18,21 +18,20 @@ VERSION=${1:-stable}
 
 set -eo pipefail -o nounset
 
-function check_platform_arch {
+check_platform_arch() {
   local supported="linux-amd64 darwin-amd64"
 
   if ! echo "${supported}" | tr ' ' '\n' | grep -q "${PLATFORM}-${ARCH}"; then
     cat <<EOF
 
-${PROGRAM} is not currently supported on ${PLATFORM}-${ARCH}.
+The Deis Workflow CLI (deis) is not currently supported on ${PLATFORM}-${ARCH}.
 
-See https://github.com/deis/workflow for more information.
+See https://deis.com/workflow/ for more information.
 
 EOF
   fi
 }
 
-PROGRAM="deis"
 PLATFORM="$(uname | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
 # https://storage.googleapis.com/workflow-cli-release/v2.0.0/deis-v2.0.0-darwin-386
@@ -57,9 +56,9 @@ chmod +x deis
 
 cat <<EOF
 
-${PROGRAM} is now available in your current directory.
+The Deis Workflow CLI (deis) is now available in your current directory.
 
-To learn more about deis, execute:
+To learn more about Deis Workflow, execute:
 
     $ ./deis --help
 


### PR DESCRIPTION
Closes #195.

Test method:

```
$ cat install-v2.sh | sh -s v2.10.0
Downloading deis-v2.10.0-darwin-amd64 From Google Cloud Storage...

The Deis Workflow CLI (deis) is now available in your current directory.

To learn more about Deis Workflow, execute:

    $ ./deis --help
```

```
$ cat install-v2.sh | sh
Downloading deis-stable-darwin-amd64 From Google Cloud Storage...

The Deis Workflow CLI (deis) is now available in your current directory.

To learn more about Deis Workflow, execute:

    $ ./deis --help
```